### PR TITLE
Change build sets to stop warnings

### DIFF
--- a/.github/actions/get_cache_key/action.yml
+++ b/.github/actions/get_cache_key/action.yml
@@ -29,5 +29,5 @@ runs:
         SUBMODULE=${{ inputs.submodule }}
         SHA=$(git submodule status ${SUBMODULE} | sed -e 's/^-//g' -e 's/^+//g' -e 's/^U//g' | awk '{ print $1 }')
         KEY=${SUBMODULE}-${{ inputs.flavor }}_${{ inputs.arch }}_${SHA}_${{ inputs.extras }}
-        echo "::set-output name=key::${KEY}"
+        echo "key=${KEY}" >> $GITHUB_OUTPUT  
       shell: bash

--- a/.github/actions/numpy_vers/action.yml
+++ b/.github/actions/numpy_vers/action.yml
@@ -100,6 +100,6 @@ runs:
             ;;
         esac
 
-        echo "::set-output name=build::${NUMPY_BUILD_VERSION}"
-        echo "::set-output name=dep::${NUMPY_DEP_VERSION}"
+        echo "build=${NUMPY_BUILD_VERSION}" >> $GITHUB_OUTPUT  
+        echo "dep=${NUMPY_DEP_VERSION}" >> $GITHUB_OUTPUT
       shell: bash

--- a/.github/actions/win-numpy-vers/action.yml
+++ b/.github/actions/win-numpy-vers/action.yml
@@ -100,6 +100,6 @@ runs:
             ;;
         esac
 
-        echo "::set-output name=build::${NUMPY_BUILD_VERSION}"
-        echo "::set-output name=dep::${NUMPY_DEP_VERSION}"
+        echo "build=${NUMPY_BUILD_VERSION}" >> $GITHUB_OUTPUT  
+        echo "dep=${NUMPY_DEP_VERSION}" >> $GITHUB_OUTPUT
       shell: msys2 {0}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -33,10 +33,10 @@ jobs:
       is-prerelease: ${{ steps.check-version.outputs.is-prerelease }}
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Check VERSION file matches pushed Git tag and check if prerelease
@@ -56,23 +56,25 @@ jobs:
 
           # Tag for this release (version with leading v)
           tag=$(echo "${{ github.ref }}" | sed -e 's|^refs/tags/||')
-          echo ::set-output name=release-tag::${tag}
+          echo "release-tag=${tag}" >> $GITHUB_OUTPUT
 
           # Version without leading v
           version=$(cat VERSION)
-          echo ::set-output name=version::${version}
+          echo "version=${version}" >> $GITHUB_OUTPUT
 
           # Is this a prerelease or not?
           pip install semver
           cat <<EOF | python - "${{ github.ref }}"
           import sys
+          import os
           import semver
           ref = sys.argv[1]
           prefix = "refs/tags/v"
           assert ref.startswith(prefix)
           parsed = semver.parse_version_info(ref[len(prefix):])
-          print("::set-output name=is-prerelease::{}".format("true" if parsed.prerelease else "false"))
-          print("::set-output name=release-notes-file::{}".format("" if parsed.prerelease else "RELEASE_NOTES.md"))
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+              print("is-prerelease={}".format("true" if parsed.prerelease else "false"), file=fh)
+              print("release-notes-file={}".format("" if parsed.prerelease else "RELEASE_NOTES.md"), file=fh)
           EOF
       - uses: softprops/action-gh-release@v1
         with:
@@ -86,7 +88,7 @@ jobs:
     env:
       swig_hash: "90cdbee6a69d13b39d734083b9f91069533b0d7b"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: "swig/swig"
           ref: ${{ env.swig_hash }}
@@ -121,7 +123,7 @@ jobs:
       - run: |
           make install
         if: steps.swig-build-cache.outputs.cache-hit != 'true'
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: ${{ github.job }}
           path: ${{ github.workspace }}/build-static/
@@ -135,7 +137,7 @@ jobs:
     env:
       swig_hash: "90cdbee6a69d13b39d734083b9f91069533b0d7b"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: "swig/swig"
           ref: ${{ env.swig_hash }}
@@ -164,7 +166,7 @@ jobs:
       - run: |
           make install
         if: steps.swig-build-cache.outputs.cache-hit != 'true'
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: ${{ github.job }}
           path: ${{ github.workspace }}/build-static/
@@ -206,7 +208,7 @@ jobs:
           cd sox-14.4.2
           make install
         if: steps.sox-build-cache.outputs.cache-hit != 'true'
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: ${{ github.job }}
           path: ${{ github.workspace }}/sox-build/
@@ -222,10 +224,10 @@ jobs:
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "swig_Linux"
           path: ${{ github.workspace }}/native_client/ds-swig/
@@ -257,7 +259,7 @@ jobs:
       - name: Auditwheel repair
         run: |
           auditwheel repair native_client/ctcdecode/dist/*.whl
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "coqui_stt_ctcdecoder-Linux-${{ matrix.python-version }}.whl"
           path: ${{ github.workspace }}/wheelhouse/*.whl
@@ -270,13 +272,13 @@ jobs:
       matrix:
         samplerate: ["8000", "16000"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.7"
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "coqui_stt_ctcdecoder-Linux-3.7.whl"
       - run: |
@@ -310,11 +312,11 @@ jobs:
           cp /tmp/train*/output_graph.* /tmp/checkpoint.tar.xz ${{ github.workspace }}/tmp/
       - run: |
           ls -hal /tmp/ ${{ github.workspace }}/tmp/
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "test-model.tflite-${{ matrix.samplerate }}.zip"
           path: ${{ github.workspace }}/tmp/output_graph.tflite
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "test-checkpoint.${{ matrix.samplerate }}.zip"
           path: ${{ github.workspace }}/tmp/checkpoint.tar.xz
@@ -327,7 +329,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}:${{ github.workspace }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: 'recursive'
@@ -339,18 +341,18 @@ jobs:
         run: |
           /opt/python/cp37-cp37m/bin/python -m venv /tmp/venv
           echo "/tmp/venv/bin" >> $GITHUB_PATH
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "libsox3_Linux"
           path: ${{ github.workspace }}/sox-build/
       - run: ./ci_scripts/tf-setup.sh
       - run: ./ci_scripts/host-build.sh
       - run: ./ci_scripts/package.sh
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "native_client.tflite.Linux.tar.xz"
           path: ${{ github.workspace }}/artifacts/native_client.tar.xz
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "libstt.tflite.Linux.zip"
           path: ${{ github.workspace }}/artifacts/libstt.zip
@@ -366,10 +368,10 @@ jobs:
       volumes:
         - ${{ github.workspace }}:${{ github.workspace }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "native_client.tflite.Linux.tar.xz"
           path: ${{ github.workspace }}/tensorflow/bazel-bin/native_client/
@@ -381,7 +383,7 @@ jobs:
         run: |
           cd ${{ github.workspace }}/tensorflow/bazel-bin/native_client/
           tar xf native_client.tar.xz
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "swig_Linux"
           path: ${{ github.workspace }}/native_client/ds-swig/
@@ -402,7 +404,7 @@ jobs:
         with:
           numpy_build: "${{ steps.get_numpy.outputs.build_version }}"
           numpy_dep: "${{ steps.get_numpy.outputs.dep_version }}"
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "stt-tflite-${{ matrix.python-version }}-Linux.whl"
           path: ${{ github.workspace }}/native_client/python/dist/*.whl
@@ -411,17 +413,17 @@ jobs:
     runs-on: ubuntu-20.04
     needs: [ build-lib-Linux, swig_Linux ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "native_client.tflite.Linux.tar.xz"
           path: ${{ github.workspace }}/tensorflow/bazel-bin/native_client/
       - run: |
           cd ${{ github.workspace }}/tensorflow/bazel-bin/native_client/
           tar xf native_client.tar.xz
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "swig_Linux"
           path: ${{ github.workspace }}/native_client/ds-swig/
@@ -430,7 +432,7 @@ jobs:
           ls -hal ${{ github.workspace }}/native_client/ds-swig/bin
           ln -s ds-swig ${{ github.workspace }}/native_client/ds-swig/bin/swig
           chmod +x ${{ github.workspace }}/native_client/ds-swig/bin/ds-swig ${{ github.workspace }}/native_client/ds-swig/bin/swig
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 12
       - uses: actions/cache@v2
@@ -447,11 +449,11 @@ jobs:
         with:
           nodejs_versions: "12.7.0 13.0.0 14.0.0 15.0.0 16.0.0 17.0.1"
           electronjs_versions: "12.0.0 13.0.0 14.0.0 15.0.0 16.0.0"
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "nodewrapper-tflite-Linux_amd64.tar.gz"
           path: ${{ github.workspace }}/native_client/javascript/wrapper.tar.gz
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "stt_intermediate-tflite-Linux.tgz"
           path: ${{ github.workspace }}/native_client/javascript/stt-*.tgz
@@ -463,11 +465,11 @@ jobs:
       volumes:
         - ${{ github.workspace }}:${{ github.workspace }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: 'recursive'
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
       - name: Install dependencies
@@ -484,11 +486,11 @@ jobs:
       - run: BAZEL_WASM_EXTRA_FLAGS="--//native_client:wasm_emit=es6" ./ci_scripts/wasm-build.sh
       - run: make -C native_client/wasm clean pack
         shell: bash
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "libstt.tflite.wasm.zip"
           path: ${{ github.workspace }}/artifacts/libstt.zip
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "libstt.tflite.wasm.es6.tgz"
           path: ${{ github.workspace }}/native_client/wasm/stt-wasm-*.tgz
@@ -503,11 +505,11 @@ jobs:
     env:
       CI_TMP_DIR: ${{ github.workspace }}/tmp/
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "libstt.tflite.wasm.es6.tgz"
           path: ${{ env.CI_TMP_DIR }}
@@ -526,10 +528,10 @@ jobs:
       CI_TMP_DIR: ${{ github.workspace }}/tmp/
       STT_TEST_MODEL: ${{ github.workspace }}/tmp/output_graph.tflite
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "native_client.tflite.Linux.tar.xz"
           path: ${{ env.CI_TMP_DIR }}
@@ -537,7 +539,7 @@ jobs:
           cd ${{ env.CI_TMP_DIR }}
           mkdir ds && cd ds && tar xf ../native_client.tar.xz
           ls -lh
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "test-model.tflite-${{ matrix.samplerate }}.zip"
           path: ${{ env.CI_TMP_DIR }}
@@ -564,19 +566,19 @@ jobs:
       CI_TMP_DIR: ${{ github.workspace }}/tmp/
       STT_TEST_MODEL: ${{ github.workspace }}/tmp/output_graph.tflite
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - run: |
           sudo apt-get install -y --no-install-recommends sox
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "stt-tflite-${{ matrix.python-version }}-Linux.whl"
           path: ${{ env.CI_TMP_DIR }}
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "test-model.tflite-${{ matrix.samplerate }}.zip"
           path: ${{ env.CI_TMP_DIR }}
@@ -605,20 +607,20 @@ jobs:
       CI_TMP_DIR: ${{ github.workspace }}/tmp/
       STT_TEST_MODEL: ${{ github.workspace }}/tmp/output_graph.tflite
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "stt-tflite-${{ matrix.python-version }}-Linux.whl"
           path: ${{ env.CI_TMP_DIR }}
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "coqui_stt_ctcdecoder-Linux-${{ matrix.python-version }}.whl"
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "test-model.tflite-${{ matrix.samplerate }}.zip"
           path: ${{ env.CI_TMP_DIR }}
@@ -648,19 +650,19 @@ jobs:
       CI_TMP_DIR: ${{ github.workspace }}/tmp/
       STT_TEST_MODEL: ${{ github.workspace }}/tmp/output_graph.tflite
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.nodejs-version }}
       - run: |
           sudo apt-get install -y --no-install-recommends sox
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "stt_intermediate-tflite-Linux.tgz"
           path: ${{ env.CI_TMP_DIR }}
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "test-model.tflite-${{ matrix.samplerate }}.zip"
           path: ${{ env.CI_TMP_DIR }}
@@ -699,19 +701,19 @@ jobs:
       CI_TMP_DIR: ${{ github.workspace }}/tmp/
       STT_TEST_MODEL: ${{ github.workspace }}/tmp/output_graph.tflite
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 12
       - run: |
           sudo apt-get install -y --no-install-recommends sox
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "stt_intermediate-tflite-Linux.tgz"
           path: ${{ env.CI_TMP_DIR }}
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "test-model.tflite-${{ matrix.samplerate }}.zip"
           path: ${{ env.CI_TMP_DIR }}
@@ -742,13 +744,13 @@ jobs:
     runs-on: ubuntu-20.04
     if: ${{ github.event_name == 'pull_request' }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.7
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "coqui_stt_ctcdecoder-Linux-3.7.whl"
       - run: |
@@ -774,11 +776,11 @@ jobs:
         samplerate: ["8000", "16000"]
         pyver: ["3.7"]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.pyver }}
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "coqui_stt_ctcdecoder-Linux-${{ matrix.pyver }}.whl"
       - run: |
@@ -814,19 +816,19 @@ jobs:
           cp /tmp/train/output_graph.pbmm ${CI_ARTIFACTS_DIR}
 
           time ./bin/run-ci-ldc93s1_checkpoint.sh
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: ${{ github.job }}-output_graph.pb
           path: ${{ github.workspace }}/artifacts/output_graph.pb
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: ${{ github.job }}-output_graph.pbmm
           path: ${{ github.workspace }}/artifacts/output_graph.pbmm
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: ${{ github.job }}-output_graph.tflite
           path: ${{ github.workspace }}/artifacts/output_graph.tflite
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: ${{ github.job }}-checkpoint.tar.xz
           path: ${{ github.workspace }}/artifacts/checkpoint.tar.xz
@@ -840,11 +842,11 @@ jobs:
         samplerate: ["8000", "16000"]
         pyver: ["3.7"]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.pyver }}
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "coqui_stt_ctcdecoder-Linux-${{ matrix.pyver }}.whl"
       - run: |
@@ -894,11 +896,11 @@ jobs:
         samplerate: ["8000", "16000"]
         pyver: ["3.7"]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.pyver }}
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "coqui_stt_ctcdecoder-Linux-${{ matrix.pyver }}.whl"
       - run: |
@@ -938,11 +940,11 @@ jobs:
         samplerate: ["8000", "16000"]
         pyver: ["3.7"]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.pyver }}
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "coqui_stt_ctcdecoder-Linux-${{ matrix.pyver }}.whl"
       - run: |
@@ -978,11 +980,11 @@ jobs:
         samplerate: ["8000", "16000"]
         pyver: ["3.7"]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.pyver }}
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "coqui_stt_ctcdecoder-Linux-${{ matrix.pyver }}.whl"
       - run: |
@@ -1014,14 +1016,14 @@ jobs:
         samplerate: ["8000", "16000"]
         pyver: ["3.7"]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.pyver }}
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "coqui_stt_ctcdecoder-Linux-${{ matrix.pyver }}.whl"
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "training-basic-tests-checkpoint.tar.xz"
       - name: Extract training checkpoint
@@ -1069,8 +1071,8 @@ jobs:
     needs: [create-release]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Update pip and install deps
@@ -1099,57 +1101,57 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     needs: [create-release, build-python-Linux, build-python-macOS, build-python-Windows, build-python-LinuxArmv7, build-python-LinuxAarch64]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Update pip and install twine
         run: |
           python -m pip install -U pip
           python -m pip install -U twine
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: stt-tflite-3.6.8-macOS.whl
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: stt-tflite-3.7.9-macOS.whl
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: stt-tflite-3.8.9-macOS.whl
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: stt-tflite-3.9.4-macOS.whl
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: stt-tflite-3.10.1-macOS.whl
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: stt-tflite-3.6.8-Windows.whl
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: stt-tflite-3.7.9-Windows.whl
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: stt-tflite-3.8.8-Windows.whl
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: stt-tflite-3.9.4-Windows.whl
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: stt-tflite-3.10.0-Windows.whl
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: stt-tflite-3.6-Linux.whl
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: stt-tflite-3.7-Linux.whl
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: stt-tflite-3.8-Linux.whl
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: stt-tflite-3.9-Linux.whl
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: stt-tflite-3.10-Linux.whl
       - name: Setup PyPI config
@@ -1164,16 +1166,16 @@ jobs:
       # PyPI only supports ARM wheels built on manylinux images, but those aren't
       # ready for use yet, so we upload our wheels to the corresponding release
       # for this tag.
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: stt-tflite-3.7-armv7.whl
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: stt-tflite-3.7-aarch64.whl
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: stt-tflite-3.9-armv7.whl
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: stt-tflite-3.9-aarch64.whl
       - name: Upload artifacts to GitHub release
@@ -1188,40 +1190,40 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     needs: [create-release, build-lib-Windows, build-lib-Linux, build-universal-lib-macOS, build-lib-LinuxAarch64, build-lib-LinuxArmv7]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: libstt.tflite.Linux.zip
       - run: mv libstt.zip libstt.tflite.Linux.zip
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: native_client.tflite.Linux.tar.xz
       - run: mv native_client.tar.xz native_client.tflite.Linux.tar.xz
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: libstt.tflite.macOS.zip
       - run: mv libstt.zip libstt.tflite.macOS.zip
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: libstt.tflite.wasm.zip
       - run: mv libstt.zip libstt.tflite.wasm.zip
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: native_client.tflite.macOS.tar.xz
       - run: mv native_client.tar.xz native_client.tflite.macOS.tar.xz
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: libstt.tflite.Windows.zip
       - run: mv libstt.zip libstt.tflite.Windows.zip
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: native_client.tflite.Windows.tar.xz
       - run: mv native_client.tar.xz native_client.tflite.Windows.tar.xz
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: native_client.tflite.linux.armv7.tar.xz
       - run: mv native_client.tar.xz native_client.tflite.linux.armv7.tar.xz
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: native_client.tflite.linux.aarch64.tar.xz
       - run: mv native_client.tar.xz native_client.tflite.linux.aarch64.tar.xz
@@ -1240,7 +1242,7 @@ jobs:
     name: "Build Dockerfile.build image"
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: 'recursive'
@@ -1249,14 +1251,14 @@ jobs:
         run: |
           if [[ "${{ startsWith(github.ref, 'refs/tags/') }}" != "true" ]]; then
             # PR build
-            echo "::set-output name=tag::dev"
+            echo "::ccccccccccccccccccccccccccccccccccccccccccccccccccccccc name=tag::dev"
           else
             VERSION="v$(cat VERSION)"
             if [[ "${{ github.ref }}" != "refs/tags/${VERSION}" ]]; then
               echo "Pushed tag does not match VERSION file. Aborting push."
               exit 1
             fi
-            echo "::set-output name=tag::${VERSION}"
+            echo "tag=${VERSION}" >> $GITHUB_OUTPUT
           fi
       - name: Build
         run: |
@@ -1268,7 +1270,7 @@ jobs:
     needs: [upload-nc-release-assets]
     if: always()
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: 'recursive'
@@ -1296,7 +1298,7 @@ jobs:
             fi
             tags="${VERSION} latest ${{ github.sha }}"
           fi
-          echo "::set-output name=tags::${tags}"
+          echo "tags=${tags}" >> $GITHUB_OUTPUT
       - name: Build
         run: |
           set -ex
@@ -1318,45 +1320,45 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     needs: [create-release, build-ctc-decoder-Linux, build-ctc-decoder-macos, build-ctc-decoder-windows]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Update pip and install twine
         run: |
           python -m pip install -U pip
           python -m pip install -U twine
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: coqui_stt_ctcdecoder-Linux-3.6.whl
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: coqui_stt_ctcdecoder-Linux-3.7.whl
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: coqui_stt_ctcdecoder-Linux-3.8.whl
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: coqui_stt_ctcdecoder-Linux-3.9.whl
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: coqui_stt_ctcdecoder-Linux-3.10.whl
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: coqui_stt_ctcdecoder-macOS-3.6.8.whl
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: coqui_stt_ctcdecoder-macOS-3.7.9.whl
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: coqui_stt_ctcdecoder-macOS-3.8.9.whl
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: coqui_stt_ctcdecoder-macOS-3.9.4.whl
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: coqui_stt_ctcdecoder-macOS-3.10.1.whl
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: coqui_stt_ctcdecoder-windows-test.whl
       - name: Setup PyPI config
@@ -1383,10 +1385,10 @@ jobs:
       - name: Wait for PyPI index to refresh
         run: |
           sleep 60
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.7
       - run: |
@@ -1403,27 +1405,27 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     needs: [create-release, repackage-nodejs-allplatforms, build-wasm]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 12
           registry-url: 'https://registry.npmjs.org'
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Compute tag for npm from git tag
         id: compute-npm-tag
         run: |
           if [ "${{ needs.create-release.outputs.is-prerelease }}" = "true" ]; then
-            echo ::set-output name=npm-tag::prerelease
+            echo "npm-tag=prerelease" >> $GITHUB_OUTPUT
           else
-            echo ::set-output name=npm-tag::latest
+            echo "npm-tag=latest" >> $GITHUB_OUTPUT
           fi
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: stt-tflite.tgz
           path: ${{ github.workspace }}/
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: libstt.tflite.wasm.es6.tgz
           path: ${{ github.workspace }}/
@@ -1446,7 +1448,7 @@ jobs:
     env:
       swig_hash: "90cdbee6a69d13b39d734083b9f91069533b0d7b"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: "swig/swig"
           ref: ${{ env.swig_hash }}
@@ -1478,7 +1480,7 @@ jobs:
       - run: |
           make install
         if: steps.swig-build-cache.outputs.cache-hit != 'true'
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: ${{ github.job }}
           path: ${{ github.workspace }}/build-static/
@@ -1490,7 +1492,7 @@ jobs:
       matrix:
         python-version: [3.6.8, 3.7.9, 3.8.9, 3.9.4, 3.10.1]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - uses: ./.github/actions/install-python-upstream
@@ -1499,7 +1501,7 @@ jobs:
       - run: |
           python --version
           pip --version
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "swig_macOS"
           path: ${{ github.workspace }}/native_client/ds-swig/
@@ -1519,7 +1521,7 @@ jobs:
           make -C native_client/ctcdecode/ \
             NUM_PROCESSES=$(sysctl hw.ncpu |cut -d' ' -f2) \
             bindings
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "coqui_stt_ctcdecoder-macOS-${{ matrix.python-version }}.whl"
           path: ${{ github.workspace }}/native_client/ctcdecode/dist/*.whl
@@ -1534,13 +1536,13 @@ jobs:
       matrix:
         samplerate: ["8000", "16000"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.7
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "coqui_stt_ctcdecoder-macOS-3.7.9.whl"
       - run: |
@@ -1574,11 +1576,11 @@ jobs:
           cp /tmp/train*/output_graph.* /tmp/checkpoint.tar.xz ${{ github.workspace }}/tmp/
       - run: |
           ls -hal /tmp/ ${{ github.workspace }}/tmp/
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "test-model.mac.tflite-${{ matrix.samplerate }}.zip"
           path: ${{ github.workspace }}/tmp/output_graph.tflite
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "test-checkpoint.${{ matrix.samplerate }}.zip"
           path: ${{ github.workspace }}/tmp/checkpoint.tar.xz
@@ -1589,11 +1591,11 @@ jobs:
       matrix:
         arch: ["x86_64", "arm64"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: 'recursive'
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.7"
       - name: Install system deps
@@ -1640,11 +1642,11 @@ jobs:
           sudo rm -r /Library/Developer/CommandLineTools
       - run: ./ci_scripts/host-build.sh ${{ matrix.arch }}
       - run: ./ci_scripts/package.sh
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "native_client.tflite.macOS.${{ matrix.arch }}.tar.xz"
           path: ${{ github.workspace }}/artifacts/native_client.tar.xz
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "libstt.tflite.macOS.${{ matrix.arch }}.zip"
           path: ${{ github.workspace }}/artifacts/libstt.zip
@@ -1652,11 +1654,11 @@ jobs:
     name: "iOS|Build libstt+client"
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: 'recursive'
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.7"
       - name: Install system deps
@@ -1680,7 +1682,7 @@ jobs:
             tensorflow/bazel-bin/native_client/libstt.so \
             tensorflow/bazel-out/applebin_ios*/bin/native_client/stt_ios.zip \
             tensorflow/bazel-out/applebin_ios*/bin/native_client/kenlm_ios.zip
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "ios_artifacts.zip"
           path: ${{ github.workspace }}/artifacts/ios_artifacts.zip
@@ -1690,7 +1692,7 @@ jobs:
     needs: [build-lib-macOS]
     steps:
       # Download and extract individual arch packages and create universal binaries
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "native_client.tflite.macOS.x86_64.tar.xz"
       - run: |
@@ -1698,7 +1700,7 @@ jobs:
           cd nc.x86_64
           tar xvf ../native_client.tar.xz
           rm ../native_client.tar.xz
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "native_client.tflite.macOS.arm64.tar.xz"
       - run: |
@@ -1715,12 +1717,12 @@ jobs:
       - run: |
           cd nc.x86_64
           tar cvJf native_client.tar.xz .
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "native_client.tflite.macOS.tar.xz"
           path: nc.x86_64/native_client.tar.xz
       # Now do the same, but for libstt.zip
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "libstt.tflite.macOS.x86_64.zip"
       - run: |
@@ -1728,7 +1730,7 @@ jobs:
           cd libstt.x86_64
           tar xvf ../libstt.zip
           rm ../libstt.zip
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "libstt.tflite.macOS.arm64.zip"
       - run: |
@@ -1744,7 +1746,7 @@ jobs:
           done
       - run: |
           zip -r9 --junk-paths libstt.zip libstt.x86_64/*
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "libstt.tflite.macOS.zip"
           path: libstt.zip
@@ -1756,17 +1758,17 @@ jobs:
       matrix:
         python-version: [3.6.8, 3.7.9, 3.8.9, 3.9.4, 3.10.1]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "native_client.tflite.macOS.tar.xz"
           path: ${{ github.workspace }}/tensorflow/bazel-bin/native_client/
       - run: |
           cd ${{ github.workspace }}/tensorflow/bazel-bin/native_client/
           tar xf native_client.tar.xz
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "swig_macOS"
           path: ${{ github.workspace }}/native_client/ds-swig/
@@ -1779,7 +1781,7 @@ jobs:
         with:
           version: ${{ matrix.python-version }}
       # GitHub packaged version are limited to macOS deployment target 10.14
-      #- uses: actions/setup-python@v2
+      #- uses: actions/setup-python@v4
       #  with:
       #    python-version: ${{ matrix.python-version }}
       - id: get_numpy
@@ -1790,7 +1792,7 @@ jobs:
         with:
           numpy_build: "${{ steps.get_numpy.outputs.build_version }}"
           numpy_dep: "${{ steps.get_numpy.outputs.dep_version }}"
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "stt-tflite-${{ matrix.python-version }}-macOS.whl"
           path: ${{ github.workspace }}/native_client/python/dist/*.whl
@@ -1799,17 +1801,17 @@ jobs:
     runs-on: macos-12
     needs: [build-universal-lib-macOS, swig_macOS]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "native_client.tflite.macOS.tar.xz"
           path: ${{ github.workspace }}/tensorflow/bazel-bin/native_client/
       - run: |
           cd ${{ github.workspace }}/tensorflow/bazel-bin/native_client/
           tar xf native_client.tar.xz
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "swig_macOS"
           path: ${{ github.workspace }}/native_client/ds-swig/
@@ -1818,7 +1820,7 @@ jobs:
           ls -hal ${{ github.workspace }}/native_client/ds-swig/bin
           ln -s ds-swig ${{ github.workspace }}/native_client/ds-swig/bin/swig
           chmod +x ${{ github.workspace }}/native_client/ds-swig/bin/ds-swig ${{ github.workspace }}/native_client/ds-swig/bin/swig
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 12
       - uses: actions/cache@v2
@@ -1835,11 +1837,11 @@ jobs:
         with:
           nodejs_versions: "12.7.0 13.0.0 14.0.0 15.0.0 16.0.0 17.0.1"
           electronjs_versions: "12.0.0 13.0.0 14.0.0 15.0.0 16.0.0"
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "nodewrapper-tflite-macOS_amd64.tar.gz"
           path: ${{ github.workspace }}/native_client/javascript/wrapper.tar.gz
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "stt_intermediate-tflite-macOS.tgz"
           path: ${{ github.workspace }}/native_client/javascript/stt-*.tgz
@@ -1856,17 +1858,17 @@ jobs:
       CI_TMP_DIR: ${{ github.workspace }}/tmp/
       STT_TEST_MODEL: ${{ github.workspace }}/tmp/output_graph.tflite
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "native_client.tflite.macOS.tar.xz"
           path: ${{ env.CI_TMP_DIR }}
       - run: |
           cd ${{ env.CI_TMP_DIR }}
           mkdir ds && cd ds && tar xf ../native_client.tar.xz
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "test-model.tflite-${{ matrix.samplerate }}.zip"
           path: ${{ env.CI_TMP_DIR }}
@@ -1893,17 +1895,17 @@ jobs:
       CI_TMP_DIR: ${{ github.workspace }}/tmp/
       STT_TEST_MODEL: ${{ github.workspace }}/tmp/output_graph.tflite
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "stt-tflite-${{ matrix.python-version }}-macOS.whl"
           path: ${{ env.CI_TMP_DIR }}
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "test-model.tflite-${{ matrix.samplerate }}.zip"
           path: ${{ env.CI_TMP_DIR }}
@@ -1935,17 +1937,17 @@ jobs:
       CI_TMP_DIR: ${{ github.workspace }}/tmp/
       STT_TEST_MODEL: ${{ github.workspace }}/tmp/output_graph.tflite
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.nodejs-version }}
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "stt_intermediate-tflite-macOS.tgz"
           path: ${{ env.CI_TMP_DIR }}
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "test-model.tflite-${{ matrix.samplerate }}.zip"
           path: ${{ env.CI_TMP_DIR }}
@@ -1983,17 +1985,17 @@ jobs:
       CI_TMP_DIR: ${{ github.workspace }}/tmp/
       STT_TEST_MODEL: ${{ github.workspace }}/tmp/output_graph.tflite
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 12
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "stt_intermediate-tflite-macOS.tgz"
           path: ${{ env.CI_TMP_DIR }}
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "test-model.tflite-${{ matrix.samplerate }}.zip"
           path: ${{ env.CI_TMP_DIR }}
@@ -2036,16 +2038,16 @@ jobs:
           install: >-
             git
             make
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.7.9
       - run: |
           python --version
           python -m pip --version
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "swig_Windows_crosscompiled"
           path: ${{ github.workspace }}/native_client/ds-swig/
@@ -2064,7 +2066,7 @@ jobs:
           make -C native_client/ctcdecode/ \
             NUM_PROCESSES=$(nproc) \
             bindings
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "coqui_stt_ctcdecoder-windows-test.whl"
           path: ${{ github.workspace }}/native_client/ctcdecode/dist/*.whl
@@ -2090,11 +2092,11 @@ jobs:
             unzip
             zip
             make
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: 'recursive'
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.7.9
       - name: Workaround bazel bug when LLVM is installed https://github.com/bazelbuild/bazel/issues/12144
@@ -2104,11 +2106,11 @@ jobs:
       - run: ./ci_scripts/tf-setup.sh
       - run: ./ci_scripts/host-build.sh
       - run: ./ci_scripts/package.sh
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "native_client.tflite.Windows.tar.xz"
           path: ${{ github.workspace }}/artifacts/native_client.tar.xz
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "libstt.tflite.Windows.zip"
           path: ${{ github.workspace }}/artifacts/libstt.zip
@@ -2133,17 +2135,17 @@ jobs:
           update: true
           install: >-
             make
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "native_client.tflite.Windows.tar.xz"
           path: ${{ github.workspace }}/tensorflow/bazel-bin/native_client/
       - run: |
           cd tensorflow/bazel-bin/native_client/
           "C:/Program Files/7-Zip/7z.exe" x native_client.tar.xz -so | "C:/Program Files/7-Zip/7z.exe" x -aoa -si -snld -ttar -o`pwd`
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "swig_Windows_crosscompiled"
           path: ${{ github.workspace }}/native_client/ds-swig/
@@ -2153,7 +2155,7 @@ jobs:
           ls -hal native_client/ds-swig/bin
           ln -s ds-swig.exe native_client/ds-swig/bin/swig.exe
           chmod +x native_client/ds-swig/bin/ds-swig.exe native_client/ds-swig/bin/swig.exe
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Remove /usr/bin/link conflicting with MSVC link.exe
@@ -2167,7 +2169,7 @@ jobs:
         with:
           numpy_build: "${{ steps.get_numpy.outputs.build_version }}"
           numpy_dep: "${{ steps.get_numpy.outputs.dep_version }}"
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "stt-tflite-${{ matrix.python-version }}-Windows.whl"
           path: ${{ github.workspace }}/native_client/python/dist/*.whl
@@ -2188,17 +2190,17 @@ jobs:
           install: >-
             make
             tar
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "native_client.tflite.Windows.tar.xz"
           path: ${{ github.workspace }}/tensorflow/bazel-bin/native_client/
       - run: |
           cd tensorflow/bazel-bin/native_client/
           "C:/Program Files/7-Zip/7z.exe" x native_client.tar.xz -so | "C:/Program Files/7-Zip/7z.exe" x -aoa -si -snld -ttar -o`pwd`
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "swig_Windows_crosscompiled"
           path: ${{ github.workspace }}/native_client/ds-swig/
@@ -2208,7 +2210,7 @@ jobs:
           ls -hal native_client/ds-swig/bin
           ln -s ds-swig.exe native_client/ds-swig/bin/swig.exe
           chmod +x native_client/ds-swig/bin/ds-swig.exe native_client/ds-swig/bin/swig.exe
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 12
       - uses: actions/cache@v2
@@ -2225,11 +2227,11 @@ jobs:
         with:
           nodejs_versions: "12.7.0 13.0.0 14.0.0 15.0.0 16.0.0"
           electronjs_versions: "12.0.0 13.0.0 14.0.0 15.0.0 16.0.0"
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "nodewrapper-tflite-Windows_amd64.tar.gz"
           path: ${{ github.workspace }}/native_client/javascript/wrapper.tar.gz
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "STT_intermediate-tflite-Windows.tgz"
           path: ${{ github.workspace }}/native_client/javascript/stt-*.tgz
@@ -2252,11 +2254,11 @@ jobs:
           update: true
           install: >-
             vim
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
       - name: Download native_client.tar.xz
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: "native_client.tflite.Windows.tar.xz"
           path: ${{ env.CI_TMP_DIR }}
@@ -2268,7 +2270,7 @@ jobs:
           ls -hal
           popd
       - name: Download trained test model
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: "test-model.tflite-16000.zip"
           path: ${{ env.CI_TMP_DIR }}
@@ -2305,18 +2307,18 @@ jobs:
           update: true
           install: >-
             vim
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - uses: ./.github/actions/win-install-sox
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "stt-tflite-${{ matrix.python-version }}-Windows.whl"
           path: ${{ env.CI_TMP_DIR }}
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "test-model.tflite-${{ matrix.samplerate }}.zip"
           path: ${{ env.CI_TMP_DIR }}
@@ -2357,18 +2359,18 @@ jobs:
           update: true
           install: >-
             vim
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.nodejs-version }}
       - uses: ./.github/actions/win-install-sox
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "STT_intermediate-tflite-Windows.tgz"
           path: ${{ env.CI_TMP_DIR }}
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "test-model.tflite-${{ matrix.samplerate }}.zip"
           path: ${{ env.CI_TMP_DIR }}
@@ -2376,7 +2378,7 @@ jobs:
       - name: Get npm cache directory
         id: npm-cache-dir
         run: |
-          echo "::set-output name=dir::$(npm config get cache)"
+          echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v2
         id: node-modules-cache
         with:
@@ -2418,18 +2420,18 @@ jobs:
           update: true
           install: >-
             vim
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 12
       - uses: ./.github/actions/win-install-sox
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "STT_intermediate-tflite-Windows.tgz"
           path: ${{ env.CI_TMP_DIR }}
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "test-model.tflite-${{ matrix.samplerate }}.zip"
           path: ${{ env.CI_TMP_DIR }}
@@ -2440,7 +2442,7 @@ jobs:
       - name: Get npm cache directory
         id: npm-cache-dir
         run: |
-          echo "::set-output name=dir::$(npm config get cache)"
+          echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v2
         id: electron-modules-cache
         with:
@@ -2464,29 +2466,29 @@ jobs:
     runs-on: ubuntu-20.04
     needs: [build-nodejs-macOS, build-nodejs-Windows, build-nodejs-Linux, build-nodejs-LinuxArmv7, build-nodejs-LinuxAarch64]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
       - run: |
           mkdir -p /tmp/nodewrapper-tflite-macOS_amd64/
           mkdir -p /tmp/nodewrapper-tflite-Windows_amd64/
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "nodewrapper-tflite-macOS_amd64.tar.gz"
           path: /tmp/nodewrapper-macOS_amd64/
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "nodewrapper-tflite-Windows_amd64.tar.gz"
           path: /tmp/nodewrapper-Windows_amd64/
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "nodewrapper-tflite-Linux_amd64.tar.gz"
           path: /tmp/nodewrapper-Linux_amd64/
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "nodewrapper-tflite-Linux_armv7.tar.gz"
           path: /tmp/nodewrapper-Linux_armv7/
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "nodewrapper-tflite-Linux_aarch64.tar.gz"
           path: /tmp/nodewrapper-Linux_aarch64/
@@ -2499,7 +2501,7 @@ jobs:
           tar -C ${{ github.workspace }}/native_client/javascript -xzvf /tmp/nodewrapper-Linux_aarch64/wrapper.tar.gz
       - run: |
           make -C native_client/javascript clean npm-pack PROJECT_NAME=stt
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "stt-tflite.tgz"
           path: ${{ github.workspace }}/native_client/javascript/stt-*.tgz
@@ -2519,19 +2521,19 @@ jobs:
       CI_TMP_DIR: ${{ github.workspace }}/tmp/
       STT_TEST_MODEL: ${{ github.workspace }}/tmp/output_graph.tflite
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.nodejs-version }}
       - run: |
           sudo apt-get install -y --no-install-recommends sox
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "stt-tflite.tgz"
           path: ${{ env.CI_TMP_DIR }}
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "test-model.tflite-${{ matrix.samplerate }}.zip"
           path: ${{ env.CI_TMP_DIR }}
@@ -2570,19 +2572,19 @@ jobs:
       CI_TMP_DIR: ${{ github.workspace }}/tmp/
       STT_TEST_MODEL: ${{ github.workspace }}/tmp/output_graph.tflite
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 12
       - run: |
           sudo apt-get install -y --no-install-recommends sox
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "stt-tflite.tgz"
           path: ${{ env.CI_TMP_DIR }}
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "test-model.tflite-${{ matrix.samplerate }}.zip"
           path: ${{ env.CI_TMP_DIR }}
@@ -2623,17 +2625,17 @@ jobs:
       CI_TMP_DIR: ${{ github.workspace }}/tmp/
       STT_TEST_MODEL: ${{ github.workspace }}/tmp/output_graph.tflite
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.nodejs-version }}
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "stt-tflite.tgz"
           path: ${{ env.CI_TMP_DIR }}
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "test-model.tflite-${{ matrix.samplerate }}.zip"
           path: ${{ env.CI_TMP_DIR }}
@@ -2672,17 +2674,17 @@ jobs:
       CI_TMP_DIR: ${{ github.workspace }}/tmp/
       STT_TEST_MODEL: ${{ github.workspace }}/tmp/output_graph.tflite
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 12
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "stt-tflite.tgz"
           path: ${{ env.CI_TMP_DIR }}
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "test-model.tflite-${{ matrix.samplerate }}.zip"
           path: ${{ env.CI_TMP_DIR }}
@@ -2733,18 +2735,18 @@ jobs:
           update: true
           install: >-
             vim
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.nodejs-version }}
       - uses: ./.github/actions/win-install-sox
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "stt-tflite.tgz"
           path: ${{ env.CI_TMP_DIR }}
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "test-model.tflite-${{ matrix.samplerate }}.zip"
           path: ${{ env.CI_TMP_DIR }}
@@ -2752,7 +2754,7 @@ jobs:
       - name: Get npm cache directory
         id: npm-cache-dir
         run: |
-          echo "::set-output name=dir::$(npm config get cache)"
+          echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v2
         id: node-modules-cache
         with:
@@ -2795,18 +2797,18 @@ jobs:
           update: true
           install: >-
             vim
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 12
       - uses: ./.github/actions/win-install-sox
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "stt-tflite.tgz"
           path: ${{ env.CI_TMP_DIR }}
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "test-model.tflite-${{ matrix.samplerate }}.zip"
           path: ${{ env.CI_TMP_DIR }}
@@ -2817,7 +2819,7 @@ jobs:
       - name: Get npm cache directory
         id: npm-cache-dir
         run: |
-          echo "::set-output name=dir::$(npm config get cache)"
+          echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v2
         id: electron-modules-cache
         with:
@@ -2843,11 +2845,11 @@ jobs:
       SYSTEM_TARGET: rpi3
       SYSTEM_RASPBIAN: ${{ github.workspace }}/multistrap-raspbian-buster
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: 'recursive'
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.7"
       - name: Install chroot
@@ -2857,11 +2859,11 @@ jobs:
       - run: ./ci_scripts/tf-setup.sh
       - run: ./ci_scripts/armv7-build.sh
       - run: ./ci_scripts/package.sh
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "native_client.tflite.linux.armv7.tar.xz"
           path: ${{ github.workspace }}/artifacts/native_client.tar.xz
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "libstt.tflite.linux.armv7.zip"
           path: ${{ github.workspace }}/artifacts/libstt.zip
@@ -2872,11 +2874,11 @@ jobs:
       SYSTEM_TARGET: rpi3-armv8
       SYSTEM_RASPBIAN: ${{ github.workspace }}/multistrap-armbian64-buster
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: 'recursive'
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.7"
       - name: Install chroot
@@ -2886,11 +2888,11 @@ jobs:
       - run: ./ci_scripts/tf-setup.sh
       - run: ./ci_scripts/aarch64-build.sh
       - run: ./ci_scripts/package.sh
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "native_client.tflite.linux.aarch64.tar.xz"
           path: ${{ github.workspace }}/artifacts/native_client.tar.xz
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "libstt.tflite.linux.aarch64.zip"
           path: ${{ github.workspace }}/artifacts/libstt.zip
@@ -2913,18 +2915,18 @@ jobs:
       SYSTEM_TARGET: rpi3
       SYSTEM_RASPBIAN: ${{ github.workspace }}/${{ matrix.system-raspbian }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: 'recursive'
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "native_client.tflite.linux.armv7.tar.xz"
           path: ${{ github.workspace }}/tensorflow/bazel-bin/native_client/
       - run: |
           cd ${{ github.workspace }}/tensorflow/bazel-bin/native_client/
           tar xf native_client.tar.xz
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "swig_Linux"
           path: ${{ github.workspace }}/native_client/ds-swig/
@@ -2933,7 +2935,7 @@ jobs:
           ls -hal ${{ github.workspace }}/native_client/ds-swig/bin
           ln -s ds-swig ${{ github.workspace }}/native_client/ds-swig/bin/swig
           chmod +x ${{ github.workspace }}/native_client/ds-swig/bin/ds-swig ${{ github.workspace }}/native_client/ds-swig/bin/swig
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: "Install chroot"
@@ -2961,7 +2963,7 @@ jobs:
           numpy_dep: "${{ steps.get_numpy.outputs.dep_version }}"
           target: ${{ env.SYSTEM_TARGET }}
           chroot: ${{ env.SYSTEM_RASPBIAN }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "stt-tflite-${{ matrix.python-version }}-armv7.whl"
           path: ${{ github.workspace }}/native_client/python/dist/*.whl
@@ -2973,18 +2975,18 @@ jobs:
       SYSTEM_TARGET: rpi3
       SYSTEM_RASPBIAN: ${{ github.workspace }}/multistrap-raspbian-buster
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: 'recursive'
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "native_client.tflite.linux.armv7.tar.xz"
           path: ${{ github.workspace }}/tensorflow/bazel-bin/native_client/
       - run: |
           cd ${{ github.workspace }}/tensorflow/bazel-bin/native_client/
           tar xf native_client.tar.xz
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "swig_Linux"
           path: ${{ github.workspace }}/native_client/ds-swig/
@@ -2997,7 +2999,7 @@ jobs:
         uses: ./.github/actions/multistrap
         with:
           arch: armv7
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 12
       - uses: actions/cache@v2
@@ -3023,11 +3025,11 @@ jobs:
           electronjs_versions: "12.0.0 13.0.0 14.0.0 15.0.0 16.0.0"
           target: ${{ env.SYSTEM_TARGET }}
           chroot: ${{ env.SYSTEM_RASPBIAN }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "nodewrapper-tflite-Linux_armv7.tar.gz"
           path: ${{ github.workspace }}/native_client/javascript/wrapper.tar.gz
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "stt_intermediate-tflite-armv7.tgz"
           path: ${{ github.workspace }}/native_client/javascript/stt-*.tgz
@@ -3052,18 +3054,18 @@ jobs:
     steps:
       - run: |
           sudo apt-get install -y --no-install-recommends
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: 'recursive'
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "native_client.tflite.linux.aarch64.tar.xz"
           path: ${{ github.workspace }}/tensorflow/bazel-bin/native_client/
       - run: |
           cd ${{ github.workspace }}/tensorflow/bazel-bin/native_client/
           tar xf native_client.tar.xz
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "swig_Linux"
           path: ${{ github.workspace }}/native_client/ds-swig/
@@ -3072,7 +3074,7 @@ jobs:
           ls -hal ${{ github.workspace }}/native_client/ds-swig/bin
           ln -s ds-swig ${{ github.workspace }}/native_client/ds-swig/bin/swig
           chmod +x ${{ github.workspace }}/native_client/ds-swig/bin/ds-swig ${{ github.workspace }}/native_client/ds-swig/bin/swig
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: "Install chroot"
@@ -3100,7 +3102,7 @@ jobs:
           numpy_dep: "${{ steps.get_numpy.outputs.dep_version }}"
           target: ${{ env.SYSTEM_TARGET }}
           chroot: ${{ env.SYSTEM_RASPBIAN }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "stt-tflite-${{ matrix.python-version }}-aarch64.whl"
           path: ${{ github.workspace }}/native_client/python/dist/*.whl
@@ -3112,18 +3114,18 @@ jobs:
       SYSTEM_TARGET: rpi3-armv8
       SYSTEM_RASPBIAN: ${{ github.workspace }}/multistrap-armbian64-buster
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: 'recursive'
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "native_client.tflite.linux.aarch64.tar.xz"
           path: ${{ github.workspace }}/tensorflow/bazel-bin/native_client/
       - run: |
           cd ${{ github.workspace }}/tensorflow/bazel-bin/native_client/
           tar xf native_client.tar.xz
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "swig_Linux"
           path: ${{ github.workspace }}/native_client/ds-swig/
@@ -3136,7 +3138,7 @@ jobs:
         uses: ./.github/actions/multistrap
         with:
           arch: aarch64
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 12
       - uses: actions/cache@v2
@@ -3162,11 +3164,11 @@ jobs:
           electronjs_versions: "12.0.0 13.0.0 14.0.0 15.0.0 16.0.0"
           target: ${{ env.SYSTEM_TARGET }}
           chroot: ${{ env.SYSTEM_RASPBIAN }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "nodewrapper-tflite-Linux_aarch64.tar.gz"
           path: ${{ github.workspace }}/native_client/javascript/wrapper.tar.gz
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "stt_intermediate-tflite-aarch64.tgz"
           path: ${{ github.workspace }}/native_client/javascript/stt-*.tgz
@@ -3195,7 +3197,7 @@ jobs:
       DEBIAN_FRONTEND: "noninteractive"
       SYSTEM_RASPBIAN: ${{ github.workspace }}/chroot-${{ matrix.arch }}-${{ matrix.system }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
       - name: "Install and setup chroot"
@@ -3207,7 +3209,7 @@ jobs:
       - name: "Create a chroot tarball"
         run: |
           sudo tar -cf - -C ${{ env.SYSTEM_RASPBIAN }}/ --one-file-system . | xz -9 -T0 > ${{ github.workspace }}/chroot.tar.xz
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: chroot-${{ matrix.arch }}-${{ matrix.system }}
           path: ${{ github.workspace }}/chroot.tar.xz
@@ -3278,10 +3280,10 @@ jobs:
         run: |
           sudo apt-get update -y
           sudo apt-get install -y --no-install-recommends qemu-user-static
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "chroot-${{ matrix.arch }}-${{ matrix.system }}"
           path: ${{ env.CI_TMP_DIR }}/
@@ -3289,14 +3291,14 @@ jobs:
           mkdir ${{ env.SYSTEM_RASPBIAN }}/
           sudo tar -xf ${{ env.CI_TMP_DIR }}/chroot.tar.xz -C ${{ env.SYSTEM_RASPBIAN }}/
           rm ${{ env.CI_TMP_DIR }}/chroot.tar.xz
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "native_client.tflite.linux.${{ matrix.arch }}.tar.xz"
           path: ${{ env.CI_TMP_DIR }}/
       - run: |
           cd ${{ env.CI_TMP_DIR }}/
           mkdir ds && cd ds && tar xf ../native_client.tar.xz
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "test-model.tflite-${{ matrix.samplerate }}.zip"
           path: ${{ env.CI_TMP_DIR }}/
@@ -3396,10 +3398,10 @@ jobs:
         run: |
           sudo apt-get update -y
           sudo apt-get install -y --no-install-recommends qemu-user-static
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "chroot-${{ matrix.arch }}-${{ matrix.system }}"
           path: ${{ env.CI_TMP_DIR }}/
@@ -3407,11 +3409,11 @@ jobs:
           mkdir ${{ env.SYSTEM_RASPBIAN }}/
           sudo tar -xf ${{ env.CI_TMP_DIR }}/chroot.tar.xz -C ${{ env.SYSTEM_RASPBIAN }}/
           rm ${{ env.CI_TMP_DIR }}/chroot.tar.xz
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "stt-tflite-${{ matrix.python-version }}-${{ matrix.arch }}.whl"
           path: ${{ env.CI_TMP_DIR }}/
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "test-model.tflite-${{ matrix.samplerate }}.zip"
           path: ${{ env.CI_TMP_DIR }}/
@@ -3456,10 +3458,10 @@ jobs:
         run: |
           sudo apt-get update -y
           sudo apt-get install -y --no-install-recommends qemu-user-static
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "chroot-${{ matrix.arch }}-buster"
           path: ${{ env.CI_TMP_DIR }}/
@@ -3471,11 +3473,11 @@ jobs:
         uses: ./.github/actions/node-install
         with:
           node: ${{ matrix.nodejs-version }}
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "stt_intermediate-tflite-${{ matrix.arch }}.tgz"
           path: ${{ env.CI_TMP_DIR }}/
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "test-model.tflite-${{ matrix.samplerate }}.zip"
           path: ${{ env.CI_TMP_DIR }}/
@@ -3519,10 +3521,10 @@ jobs:
         run: |
           sudo apt-get update -y
           sudo apt-get install -y --no-install-recommends qemu-user-static xvfb xauth
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "chroot-${{ matrix.arch }}-buster"
           path: ${{ env.CI_TMP_DIR }}/
@@ -3534,11 +3536,11 @@ jobs:
         uses: ./.github/actions/node-install
         with:
           node: 12
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "stt_intermediate-tflite-${{ matrix.arch }}.tgz"
           path: ${{ env.CI_TMP_DIR }}/
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "test-model.tflite-${{ matrix.samplerate }}.zip"
           path: ${{ env.CI_TMP_DIR }}/
@@ -3580,11 +3582,11 @@ jobs:
     name: "AndroidArmv7|Build libstt+client"
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: 'recursive'
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.7"
       - uses: actions/setup-java@v2
@@ -3595,7 +3597,7 @@ jobs:
       - run: ./ci_scripts/tf-configure.sh --android
       - run: ./ci_scripts/android-armv7-build.sh
       - run: ./ci_scripts/android-package.sh armeabi-v7a
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "native_client.tflite.android.armv7.tar.xz"
           path: ${{ github.workspace }}/artifacts/native_client.tar.xz
@@ -3603,11 +3605,11 @@ jobs:
     name: "AndroidArm64|Build libstt+client"
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: 'recursive'
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.7"
       - uses: actions/setup-java@v2
@@ -3618,7 +3620,7 @@ jobs:
       - run: ./ci_scripts/tf-configure.sh --android
       - run: ./ci_scripts/android-arm64-build.sh
       - run: ./ci_scripts/android-package.sh arm64-v8a
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "native_client.tflite.android.arm64.tar.xz"
           path: ${{ github.workspace }}/artifacts/native_client.tar.xz
@@ -3626,11 +3628,11 @@ jobs:
     name: "Androidx86_64|Build libstt+client"
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: 'recursive'
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.7"
       - uses: actions/setup-java@v2
@@ -3641,7 +3643,7 @@ jobs:
       - run: ./ci_scripts/tf-configure.sh --android
       - run: ./ci_scripts/android-x86_64-build.sh
       - run: ./ci_scripts/android-package.sh x86_64
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "native_client.tflite.android.x86_64.tar.xz"
           path: ${{ github.workspace }}/artifacts/native_client.tar.xz
@@ -3650,10 +3652,10 @@ jobs:
     runs-on: ubuntu-20.04
     needs: [build-lib-AndroidArmv7, build-lib-AndroidArm64, build-lib-Androidx86_64]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: native_client.tflite.android.armv7.tar.xz
           path: /tmp/nc
@@ -3663,7 +3665,7 @@ jobs:
           tar xvf native_client.tar.xz
           mv libstt.so libkenlm.so ${CI_TASK_DIR}/native_client/java/libstt/libs/armeabi-v7a/
           rm -f *
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: native_client.tflite.android.arm64.tar.xz
           path: /tmp/nc
@@ -3673,7 +3675,7 @@ jobs:
           tar xvf native_client.tar.xz
           mv libstt.so libkenlm.so ${CI_TASK_DIR}/native_client/java/libstt/libs/arm64-v8a/
           rm -f *
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: native_client.tflite.android.x86_64.tar.xz
           path: /tmp/nc
@@ -3711,15 +3713,15 @@ jobs:
           make GRADLE="./gradlew " -C native_client/java maven-bundle
         env:
           ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "app.apk"
           path: ${{ github.workspace }}/native_client/java/app/build/outputs/apk/release/app*.apk
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "libstt.aar"
           path: ${{ github.workspace }}/native_client/java/libstt/build/outputs/aar/libstt*.aar
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "libstt.maven.zip"
           path: ${{ github.workspace }}/native_client/java/libstt/build/libstt-*.maven.zip
@@ -3729,10 +3731,10 @@ jobs:
     needs: [create-release, build-android-apk-aar]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "libstt.aar"
           path: ${{ github.workspace }}/

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -3589,7 +3589,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.7"
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
           java-version: "8"
@@ -3612,7 +3612,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.7"
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
           java-version: "8"
@@ -3635,7 +3635,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.7"
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
           java-version: "8"
@@ -3685,10 +3685,10 @@ jobs:
           tar xvf native_client.tar.xz
           mv libstt.so libkenlm.so ${CI_TASK_DIR}/native_client/java/libstt/libs/x86_64/
           rm -f *
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "8"
+          java-version: "11"
           cache: "gradle"
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -94,7 +94,7 @@ jobs:
           ref: ${{ env.swig_hash }}
       - run: |
           mkdir -p build-static/
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: swig-build-cache
         with:
           path: build-static/
@@ -143,7 +143,7 @@ jobs:
           ref: ${{ env.swig_hash }}
       - run: |
           mkdir -p build-static/
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: swig-build-cache
         with:
           path: build-static/
@@ -182,7 +182,7 @@ jobs:
           curl -sSL https://github.com/coqui-ai/STT/releases/download/v0.10.0-alpha.7/sox-14.4.2.tar.bz2 | tar xjf -
       - run: |
           mkdir -p sox-build/
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: sox-build-cache
         with:
           path: sox-build/
@@ -435,12 +435,12 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 12
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: node-headers-cache
         with:
           path: native_client/javascript/headers/nodejs/
           key: node-headers-12.7.0_17.0.1
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: electron-headers-cache
         with:
           path: native_client/javascript/headers/electronjs/
@@ -670,7 +670,7 @@ jobs:
       - run: |
           ls -hal ${{ env.CI_TMP_DIR }}/
         if: matrix.models == 'test'
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: node-modules-cache
         with:
           path: ~/.npm/
@@ -721,7 +721,7 @@ jobs:
       - run: |
           ls -hal ${{ env.CI_TMP_DIR }}/
         if: matrix.models == 'test'
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: electron-modules-cache
         with:
           path: ~/.npm/
@@ -1251,7 +1251,7 @@ jobs:
         run: |
           if [[ "${{ startsWith(github.ref, 'refs/tags/') }}" != "true" ]]; then
             # PR build
-            echo "::ccccccccccccccccccccccccccccccccccccccccccccccccccccccc name=tag::dev"
+            echo "tag=dev" >> $GITHUB_OUTPUT
           else
             VERSION="v$(cat VERSION)"
             if [[ "${{ github.ref }}" != "refs/tags/${VERSION}" ]]; then
@@ -1454,7 +1454,7 @@ jobs:
           ref: ${{ env.swig_hash }}
       - run: |
           mkdir -p build-static/
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: swig-build-cache
         with:
           path: build-static/
@@ -1604,7 +1604,7 @@ jobs:
       - name: Select Xcode version
         run: |
           sudo xcode-select --switch /Applications/Xcode_13.1.app/Contents/Developer
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: cache
         if: matrix.arch == 'arm64'
         with:
@@ -1823,12 +1823,12 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 12
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: node-headers-cache
         with:
           path: native_client/javascript/headers/nodejs/
           key: node-headers-12.7.0_17.0.1
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: electron-headers-cache
         with:
           path: native_client/javascript/headers/electronjs/
@@ -1955,7 +1955,7 @@ jobs:
       - run: |
           ls -hal ${{ env.CI_TMP_DIR }}/
         if: matrix.models == 'test'
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: node-modules-cache
         with:
           path: ~/.npm/
@@ -2003,7 +2003,7 @@ jobs:
       - run: |
           ls -hal ${{ env.CI_TMP_DIR }}/
         if: matrix.models == 'test'
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: electron-modules-cache
         with:
           path: ~/.npm/
@@ -2213,12 +2213,12 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 12
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: node-headers-cache
         with:
           path: native_client/javascript/headers/nodejs/
           key: node-headers-win-12.7.0_16.0.0
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: electron-headers-cache
         with:
           path: native_client/javascript/headers/electronjs/
@@ -2379,7 +2379,7 @@ jobs:
         id: npm-cache-dir
         run: |
           echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: node-modules-cache
         with:
           path: ${{ steps.npm-cache-dir.outputs.dir }}
@@ -2443,7 +2443,7 @@ jobs:
         id: npm-cache-dir
         run: |
           echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: electron-modules-cache
         with:
           path: ${{ steps.npm-cache-dir.outputs.dir }}
@@ -2538,7 +2538,7 @@ jobs:
           name: "test-model.tflite-${{ matrix.samplerate }}.zip"
           path: ${{ env.CI_TMP_DIR }}
         if: matrix.models == 'test'
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: node-modules-cache
         with:
           path: ~/.npm/
@@ -2592,7 +2592,7 @@ jobs:
       - run: |
           ls -hal ${{ env.CI_TMP_DIR }}/
         if: matrix.models == 'test'
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: electron-modules-cache
         with:
           path: ~/.npm/
@@ -2640,7 +2640,7 @@ jobs:
           name: "test-model.tflite-${{ matrix.samplerate }}.zip"
           path: ${{ env.CI_TMP_DIR }}
         if: matrix.models == 'test'
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: node-modules-cache
         with:
           path: ~/.npm/
@@ -2692,7 +2692,7 @@ jobs:
       - run: |
           ls -hal ${{ env.CI_TMP_DIR }}/
         if: matrix.models == 'test'
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: electron-modules-cache
         with:
           path: ~/.npm/
@@ -2755,7 +2755,7 @@ jobs:
         id: npm-cache-dir
         run: |
           echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: node-modules-cache
         with:
           path: ${{ steps.npm-cache-dir.outputs.dir }}
@@ -2820,7 +2820,7 @@ jobs:
         id: npm-cache-dir
         run: |
           echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: electron-modules-cache
         with:
           path: ${{ steps.npm-cache-dir.outputs.dir }}
@@ -3002,12 +3002,12 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 12
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: node-headers-cache
         with:
           path: native_client/javascript/headers/nodejs/
           key: node-headers-12.7.0_17.0.1
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: electron-headers-cache
         with:
           path: native_client/javascript/headers/electronjs/
@@ -3141,12 +3141,12 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 12
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: node-headers-cache
         with:
           path: native_client/javascript/headers/nodejs/
           key: node-headers-12.7.0_17.0.1
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: electron-headers-cache
         with:
           path: native_client/javascript/headers/electronjs/

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1275,7 +1275,7 @@ jobs:
           fetch-depth: 0
           submodules: 'recursive'
       - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -1619,7 +1619,7 @@ jobs:
           export PATH="$HOME/arm-target/bin:$PATH"
 
           cd ~/arm-target
-          mkdir arm-brew && curl -L https://github.com/Homebrew/brew/tarball/3748bed378401ed75abdf32bcb3d2674d854a6f9 | tar xz --strip 1 -C arm-brew
+          mkdir arm-brew && curl -L https://github.com/Homebrew/brew/tarball/932d2cf3b77c9439a57b6a43577fc8d3b6399a62 | tar xz --strip 1 -C arm-brew
 
           export HOMEBREW_NO_AUTO_UPDATE=1
           export HOMEBREW_CACHE=~/arm-target/brew-cache

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         pyver: ["3.7"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.pyver }}
@@ -25,7 +25,7 @@ jobs:
     name: "Lin|Pre-commit checks"
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
           python-version: "3.8"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
         pyver: ["3.7"]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.pyver }}
       - name: Run training unittests
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.8"
       - name: Run pre-comit checks


### PR DESCRIPTION
Update actions to use their v3 or v4 versions to stop node12 and set-output warnings

Update our set-output to echo to $GITHUB_OUTPUT to stop the set-output warnings

Morgan Little <mlittle@lakeheadu.ca>